### PR TITLE
Dot syntax

### DIFF
--- a/src/lexer.h
+++ b/src/lexer.h
@@ -50,6 +50,9 @@ typedef enum {
     HLL_LEX_OK = 0x0,           /**< OK */
     HLL_LEX_BUF_OVERFLOW = 0x1, /**< String buffer overflow. Note that this is
                                    not reported if buffer is NULL. */
+    /// Symbol consisting entirely of dots (more than one). Common lisp
+    /// considers such tokens invalid.
+    HLL_LEX_ALL_DOT_SYMB = 0x2,
 } hll_lex_result;
 
 /** Call to initialize the lexer. */

--- a/src/parser.c
+++ b/src/parser.c
@@ -56,14 +56,13 @@ read_cons(hll_parser *parser, hll_lisp_obj_head **head) {
         hll_lexer_eat(lexer);
         *head = hll_reverse_list(expr);
     } else if (lexer->token_kind == HLL_LTOK_DOT &&
-        (lex_result = hll_lexer_eat_peek(lexer)) == HLL_LEX_OK) {
+               (lex_result = hll_lexer_eat_peek(lexer)) == HLL_LEX_OK) {
         hll_lisp_obj_head *car = NULL;
         if ((result = hll_parse(parser, &car)) == HLL_PARSE_OK) {
-            expr = hll_make_cons(ctx, car, expr);
             lex_result = hll_lexer_peek(lexer);
+            *head = hll_reverse_list(expr);
+            hll_unwrap_cons(expr)->cdr = car;
         }
-        *head = hll_reverse_list(expr);
-        hll_unwrap_cons(*head)->cdr = car;
     } else {
         result = HLL_PARSE_MISSING_RPAREN;
     }

--- a/src/parser.c
+++ b/src/parser.c
@@ -36,7 +36,8 @@ read_cons(hll_parser *parser, hll_lisp_obj_head **head) {
     hll_lisp_obj_head *expr = hll_nil;
     while (result == HLL_PARSE_OK && lex_result == HLL_LEX_OK &&
            lexer->token_kind != HLL_LTOK_RPAREN &&
-           lexer->token_kind != HLL_LTOK_EOF) {
+           lexer->token_kind != HLL_LTOK_EOF &&
+           lexer->token_kind != HLL_LTOK_DOT) {
         hll_lisp_obj_head *car = NULL;
         result = hll_parse(parser, &car);
 
@@ -48,13 +49,21 @@ read_cons(hll_parser *parser, hll_lisp_obj_head **head) {
     }
 
     // Finalize
-
     if (result != HLL_PARSE_OK) {
     } else if (lex_result != HLL_LEX_OK) {
         result = HLL_PARSE_LEX_FAILED;
     } else if (lexer->token_kind == HLL_LTOK_RPAREN) {
         hll_lexer_eat(lexer);
         *head = hll_reverse_list(expr);
+    } else if (lexer->token_kind == HLL_LTOK_DOT &&
+        (lex_result = hll_lexer_eat_peek(lexer)) == HLL_LEX_OK) {
+        hll_lisp_obj_head *car = NULL;
+        if ((result = hll_parse(parser, &car)) == HLL_PARSE_OK) {
+            expr = hll_make_cons(ctx, car, expr);
+            lex_result = hll_lexer_peek(lexer);
+        }
+        *head = hll_reverse_list(expr);
+        hll_unwrap_cons(*head)->cdr = car;
     } else {
         result = HLL_PARSE_MISSING_RPAREN;
     }

--- a/tests/test_lisp_runtime.c
+++ b/tests/test_lisp_runtime.c
@@ -406,6 +406,29 @@ test_lisp_eval_nested_function_calls(void) {
     TEST_ASSERT(strcmp(buffer, "14\n") == 0);
 }
 
+static void 
+test_lisp_prints_dotted_list(void) {
+    char const *source = "(a b . (c d))";
+    char buffer[4096];
+
+    hll_lisp_ctx ctx = hll_default_ctx();
+    hll_init_libc_no_gc(&ctx);
+
+    hll_lexer lexer = hll_lexer_create(source, buffer, sizeof(buffer));
+    hll_parser parser = hll_parser_create(&lexer, &ctx);
+
+    hll_lisp_obj_head *obj = NULL;
+    hll_parse_result result = hll_parse(&parser, &obj);
+    TEST_ASSERT(result == HLL_PARSE_OK);
+
+    FILE *out = tmpfile();
+    hll_lisp_print(out, obj);
+
+    fseek(out, 0, SEEK_SET);
+    fgets(buffer, sizeof(buffer), out);
+    TEST_ASSERT(strcmp(buffer, "(a b c d)") == 0);
+}
+
 #define TCASE(_name) \
     { #_name, _name }
 
@@ -427,4 +450,5 @@ TEST_LIST = { TCASE(test_lisp_print_nil),
               TCASE(test_mul_multiple_args),
               TCASE(test_div_multiple_args),
               TCASE(test_lisp_eval_nested_function_calls),
+              TCASE(test_lisp_prints_dotted_list),
               { NULL, NULL } };

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -299,21 +299,57 @@ test_parser_parses_nil(void) {
     TEST_ASSERT(obj->kind == HLL_LOBJ_NIL);
 }
 
-#if 0
 static void
-test_parser_parses_quoted_list(void) {
+test_parser_parses_simple_dotted_cons(void) {
+    char const *source = "(abc . 123)";
+    char buffer[4096];
+
+    hll_lisp_ctx ctx = hll_default_ctx();
+    hll_init_libc_no_gc(&ctx);
+
+    hll_lexer lexer = hll_lexer_create(source, buffer, sizeof(buffer));
+    hll_parser parser = hll_parser_create(&lexer, &ctx);
+
+    hll_parse_result result;
+    hll_lisp_obj_head *obj;
+
+    result = hll_parse(&parser, &obj);
+    TEST_ASSERT(result == HLL_PARSE_OK);
+    TEST_ASSERT(obj->kind == HLL_LOBJ_CONS);
+
+    hll_lisp_cons *cons = hll_unwrap_cons(obj);
+    TEST_ASSERT(cons->car->kind == HLL_LOBJ_SYMB);
+    TEST_ASSERT(cons->cdr->kind == HLL_LOBJ_INT);
 }
 
 static void
-test_parser_parses_quoted_symbol(void) {
-    TEST_ASSERT(0);
-}
+test_parser_parses_dotted_list(void) {
+    char const *source = "(a b c . 123)";
+    char buffer[4096];
 
-static void
-test_parser_parses_quoted_int(void) {
-    TEST_ASSERT(0);
+    hll_lisp_ctx ctx = hll_default_ctx();
+    hll_init_libc_no_gc(&ctx);
+
+    hll_lexer lexer = hll_lexer_create(source, buffer, sizeof(buffer));
+    hll_parser parser = hll_parser_create(&lexer, &ctx);
+
+    hll_parse_result result;
+    hll_lisp_obj_head *obj;
+
+    result = hll_parse(&parser, &obj);
+    TEST_ASSERT(result == HLL_PARSE_OK);
+    TEST_ASSERT(obj->kind == HLL_LOBJ_CONS);
+
+    hll_lisp_cons *cons = hll_unwrap_cons(obj);
+    TEST_ASSERT(cons->car->kind == HLL_LOBJ_SYMB);
+    cons = hll_unwrap_cons(obj);
+    TEST_ASSERT(cons->car->kind == HLL_LOBJ_SYMB);
+    cons = hll_unwrap_cons(obj);
+    TEST_ASSERT(cons->car->kind == HLL_LOBJ_SYMB);
+    cons = hll_unwrap_cons(obj);
+    TEST_ASSERT(cons->car->kind == HLL_LOBJ_SYMB);
+    TEST_ASSERT(cons->cdr->kind == HLL_LOBJ_INT);
 }
-#endif
 
 #define TCASE(_name) \
     { #_name, _name }
@@ -321,9 +357,6 @@ test_parser_parses_quoted_int(void) {
 TEST_LIST = { TCASE(test_parser_reports_eof),
               TCASE(test_parser_parses_num),
               TCASE(test_parser_parses_symbol),
-              /* TCASE(test_parser_parses_quoted_symbol), */
-              /* TCASE(test_parser_parses_quoted_int), */
-              /* TCASE(test_parser_parses_quoted_list), */
               TCASE(test_parser_parses_one_element_list),
               TCASE(test_parser_parses_list),
               TCASE(test_parser_parses_nested_lists),
@@ -331,5 +364,7 @@ TEST_LIST = { TCASE(test_parser_reports_eof),
               TCASE(test_parser_returns_eof_arbitrary_amount_of_times),
               TCASE(test_parser_reports_stary_rparen),
               TCASE(test_parser_parses_nil),
+              TCASE(test_parser_parses_simple_dotted_cons),
+              TCASE(test_parser_parses_dotted_list),
               { NULL, NULL } };
 

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -342,13 +342,12 @@ test_parser_parses_dotted_list(void) {
 
     hll_lisp_cons *cons = hll_unwrap_cons(obj);
     TEST_ASSERT(cons->car->kind == HLL_LOBJ_SYMB);
-    cons = hll_unwrap_cons(obj);
+    cons = hll_unwrap_cons(cons->cdr);
     TEST_ASSERT(cons->car->kind == HLL_LOBJ_SYMB);
-    cons = hll_unwrap_cons(obj);
-    TEST_ASSERT(cons->car->kind == HLL_LOBJ_SYMB);
-    cons = hll_unwrap_cons(obj);
+    cons = hll_unwrap_cons(cons->cdr);
     TEST_ASSERT(cons->car->kind == HLL_LOBJ_SYMB);
     TEST_ASSERT(cons->cdr->kind == HLL_LOBJ_INT);
+
 }
 
 #define TCASE(_name) \


### PR DESCRIPTION
Create support for lists containing dot (.).
Examples: (a b . (c d)) is equal to (a b c d). (a . 123) Creates cons which car is a and cdr is 123.